### PR TITLE
changed hover-property border to outline

### DIFF
--- a/styles/assets.css
+++ b/styles/assets.css
@@ -39,7 +39,7 @@
 }
 
 .btn-light:hover {
-  border: solid 2px;
+  outline: 2px solid;
   border-color: rgba(41, 171, 226, 1);
   color: rgba(41, 171, 226, 1);
   box-shadow: 0px 5px 4px 1px rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
Die Buttons mit der Klasse btn-light vergößern sich beim Hovern auf jeder Seite um 1px, da das Property "border: solid 2px" angegeben ist. Das führt dazu, dass sich andere Elemente leicht verschieben.

Lösung: es wird nun das Property "outline" verwendet, dadurch wird die Größe des Elements nicht beeinflusst.