### PR TITLE
Scrallbar

### DIFF
--- a/styles/contacts.css
+++ b/styles/contacts.css
@@ -1,3 +1,6 @@
+body, html {
+  overflow: hidden;
+}
 .contact-view {
   display: flex;
   justify-content: flex-start;
@@ -11,9 +14,10 @@
   flex-direction: column;
   align-items: center;
   width: 456px;
-  height: calc(100dvh - 160px);
+  max-height: calc(100vh - 160px);
   padding: 32px 24px;
-  overflow: visible;
+  overflow-y: auto;
+  overflow-x: hidden;
   scrollbar-width: 24px;
   scrollbar-color: rgba(168, 168, 168, 1);
   background-color: rgba(255, 255, 255, 1);

--- a/styles/render_contacts.css
+++ b/styles/render_contacts.css
@@ -108,28 +108,12 @@
 }
 
 .contact-list-wrapper {
-    max-height: 956px;
+    max-height: calc(100vh - 160px);
     overflow-y: auto;
-    scrollbar-width: thin;
+    overflow-x: hidden;
+    scrollbar-width: thin; 
     scrollbar-color: #A8A8A8 transparent;
-}
-
-.contact-list-wrapper::-webkit-scrollbar {
-    width: 6px;
-}
-
-.contact-list-wrapper::-webkit-scrollbar-track {
-    background: transparent;
-}
-
-.contact-list-wrapper::-webkit-scrollbar-thumb {
-    background-color: #A8A8A8;
-    border-radius: 10px;
-    border: 1px solid transparent;
-}
-
-.contact-list-wrapper::-webkit-scrollbar-thumb:hover {
-    background-color: #888;
+    position: relative;
 }
 
 .contact-detail-wrapper {


### PR DESCRIPTION
- Scrallbalken von unten und rechts bei der Seite Contacts entfernt
- höhe angepasst für alle Bildschirmhöhen (contact-list-wrapper)
- wenn wir mehr Kontakte haben wird der Scrallbalken kürzer
![Screenshot 2025-03-18 103724](https://github.com/user-attachments/assets/5fb2d018-6cb2-4ab3-adba-7fb8fbd71fb6)
![Screenshot 2025-03-18 112331](https://github.com/user-attachments/assets/71dd9096-85c4-4141-ad0c-adb757b56cb1)
