### PR TITLE
renderContacts - delete getRandomColor()

### DIFF
--- a/scripts/renderContacts.js
+++ b/scripts/renderContacts.js
@@ -41,18 +41,6 @@ document.addEventListener('DOMContentLoaded', initContacts);
 
 
 /**
- * Returns a random color from a predefined color palette.
- * This ensures that contact icons have varied colors.
- *
- * @returns {string} A random hex color code (e.g., "#FF5733").
- */
-function getRandomColor() {
-    const colors = ['#6E52FF', '#FC71FF', '#FFBB2B', '#1FD7C1', '#462F8A', '#20B2AA'];
-    return colors[Math.floor(Math.random() * colors.length)];
-}
-
-
-/**
  * Groups contacts alphabetically based on the first letter of their name.
  * Invalid contacts (missing or incorrectly formatted) are ignored.
  * 


### PR DESCRIPTION
Bei renderContacts.js wurde getRandomColor() entfernt, da es nicht benötigt wird.