### PR TITLE
Bug Fix Board:  Save new task to db with empty array placeholders 

### DIFF
--- a/scripts/db.js
+++ b/scripts/db.js
@@ -85,6 +85,18 @@ function cleanSubtasks(subtasksRaw) {
 }
 
 
+/**
+ * Cleans the raw task data object by processing each task's `assignedUsers` and `subtasks` fields.
+ * 
+ * - If the key is `"counter"`, it is added as-is without modification.
+ * - For all other tasks, the function removes placeholder entries from `assignedUsers`
+ *   and sanitizes `subtasks`.
+ * 
+ * @function
+ * @param {Object} rawData - The raw task data object retrieved from the backend.
+ * @param {Object} rawData[key] - An object representing a task or a special key like "counter".
+ * @returns {Object} A new object containing the cleaned tasks with valid assigned users and subtasks.
+ */
 function cleanRawTasksData(rawData) {
     const cleanedData = {};
     for (const [key, value] of Object.entries(rawData)) {

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -6,7 +6,7 @@ const BASE_URL = "https://da-join-project-default-rtdb.europe-west1.firebasedata
 
 
 /**
- * Fetches tasks data from the server and updates the currentTasksData array.
+ * Fetches tasks data from the server, cleans the data and updates the currentTasksData array.
  * Uses the fetch API to get data from the specified endpoint.
  * 
  * @throws Will throw an error if the fetch operation fails or the response is not okay.

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -18,9 +18,9 @@ async function fetchTasksData() {
         if (!databaseResponse.ok) {
             throw new Error(`Status: ${databaseResponse.status}`);
         }
-
-        currentTasksData = await databaseResponse.json();
-
+        const rawData = await databaseResponse.json();
+        const cleanedData = cleanRawTasksData(rawData);
+        currentTasksData = cleanedData;
     } catch (error) {
         console.error("Error fetching data:", error);
         currentTasksData = {};
@@ -48,3 +48,40 @@ async function getContacts() {
     }
     return contacts; 
 };
+
+
+function cleanAssignedUsers(assignedUsersRaw) {
+    if (!assignedUsersRaw) return [];
+
+    const usersArray = Array.isArray(assignedUsersRaw)
+        ? assignedUsersRaw
+        : Object.values(assignedUsersRaw);
+
+    return usersArray.filter(user => user !== "__placeholder__");
+}
+
+
+function cleanSubtasks(subtasksRaw) {
+    if (!subtasksRaw || subtasksRaw.placeholder) {
+        return {};
+    }
+
+    return subtasksRaw;
+}
+
+
+function cleanRawTasksData(rawData) {
+    const cleanedData = {};
+    for (const [key, value] of Object.entries(rawData)) {
+        if (key === "counter") {
+            cleanedData[key] = value;
+            continue;
+        }
+        cleanedData[key] = {
+            ...value,
+            assignedUsers: cleanAssignedUsers(value.assignedUsers),
+            subtasks: cleanSubtasks(value.subtasks)
+        };
+    }
+    return cleanedData;
+}

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -50,6 +50,14 @@ async function getContacts() {
 };
 
 
+/**
+ * Cleans the raw assigned users data by converting it to an array (if necessary)
+ * and removing placeholder entries.
+ *
+ * @function
+ * @param {Array|string[]|Object} assignedUsersRaw - The raw assigned users data (array or object).
+ * @returns {Array<string>} An array of valid assigned user names.
+ */
 function cleanAssignedUsers(assignedUsersRaw) {
     if (!assignedUsersRaw) return [];
 

--- a/scripts/db.js
+++ b/scripts/db.js
@@ -69,6 +69,13 @@ function cleanAssignedUsers(assignedUsersRaw) {
 }
 
 
+/**
+ * Cleans the raw subtasks object by removing placeholder entries if present.
+ *
+ * @function
+ * @param {Object} subtasksRaw - The raw subtasks data object.
+ * @returns {Object} A cleaned object containing only valid subtasks
+ */ 
 function cleanSubtasks(subtasksRaw) {
     if (!subtasksRaw || subtasksRaw.placeholder) {
         return {};

--- a/scripts/pushTaskToDb.js
+++ b/scripts/pushTaskToDb.js
@@ -57,7 +57,7 @@ function createNewTask(newTask, newTaskKey) {
         title: newTask.title || "",
         description: newTask.description || "",
         category: newTask.category || "",
-        assignedUsers: newTask.assignedUsers || [],
+        assignedUsers: convertArrayToFirebaseObject(newTask.assignedUsers || []),
         subtasks: convertSubtasksToObject(newTask.subtasks || []),
         priority: newTask.priority || "low",
         dueDate: newTask.dueDate || "",
@@ -72,6 +72,11 @@ function createNewTask(newTask, newTaskKey) {
  */
 function convertSubtasksToObject(subtasksArray) {
     const subtasksObject = {};
+
+    if (!Array.isArray(subtasksArray) || subtasksArray.length === 0) {
+        return { placeholder: true }; 
+    }
+
     subtasksArray.forEach((subtask, index) => {
         const subtaskId = `subtaskId${index + 1}`;
         subtasksObject[subtaskId] = {
@@ -79,6 +84,7 @@ function convertSubtasksToObject(subtasksArray) {
             completed: subtask.completed || false,
         };
     });
+
     return subtasksObject;
 }
 
@@ -224,4 +230,16 @@ function getSubtasks() {
             title: subtask.textContent.trim(),
             completed: false
         }));
+}
+
+
+function convertArrayToFirebaseObject(arr) {
+    if (!arr || arr.length === 0) {
+        return { 0: "__placeholder__" }; 
+    }
+
+    return arr.reduce((acc, val, idx) => {
+        acc[idx] = val;
+        return acc;
+    }, {});
 }

--- a/scripts/pushTaskToDb.js
+++ b/scripts/pushTaskToDb.js
@@ -233,6 +233,19 @@ function getSubtasks() {
 }
 
 
+/**
+ * Converts an array into a Firebase-compatible object where each array index becomes a key.
+ * 
+ * - If the array is empty or falsy, it returns an object with a single placeholder entry.
+ * - Otherwise, it maps each item in the array to an object property using its index as the key.
+ * 
+ * This is useful for storing array-like data in Firebase Realtime Database,
+ * which does not natively support arrays.
+ * 
+ * @function
+ * @param {Array} arr - The input array to be converted.
+ * @returns {Object} An object representation of the array suitable for Firebase.
+ */
 function convertArrayToFirebaseObject(arr) {
     if (!arr || arr.length === 0) {
         return { 0: "__placeholder__" }; 


### PR DESCRIPTION
Neue Tasks, wo keine AssignedUsers oder Subtasks angelegt oder ausgewählt sind, werden Placeholder Elemente in der Datenbank hinterlegt, damit die Datenbank die Keys speichert.
<img width="330" alt="image" src="https://github.com/user-attachments/assets/c17df177-013f-4ab5-8c9d-3e551ec85f4a" />


Die ausgelesenen Tasks werden dann auf die Placeholder Elemente gefiltert und bereinigt.
Somit können auch Tasks ohne Subtasks oder Assignees angezeigt werden:
<img width="1639" alt="image" src="https://github.com/user-attachments/assets/a3bacb16-f673-4d3c-a9c6-66e8cfd54dbf" />


Weiterhin werden neue Tasks mit Assignees und Subtasks korrekt gespeichert und angezeigt.
<img width="1639" alt="image" src="https://github.com/user-attachments/assets/3dae9273-0cb2-46c3-84b3-e006c7e49854" />
