### PR TITLE
Feature Board: patch subtask status when closing the CardDetailOverlay

### DIFF
--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -31,6 +31,7 @@ function closeBoardCardDetails(event) {
     let overlay = document.getElementById('boardCardDetails');
     let overlayContainer = document.getElementById('boardCardDetailContainer');
 
+    updateTasksInDatabase(currentTasksData);
     if (event.target.closest('.board-card-edit-container') || event.target.closest('.input-container')) {
         event.stopPropagation();
         return;

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -12,6 +12,7 @@ function showBoardCardDetails(taskId) {
     addTaskOverlayRef.innerHTML += cardDetailsOverlayHTMLTemplate(task, categoryClassName);
     renderCardDetailsAssignedUsers(currentTasksData[taskId], taskId);
     renderCardDetailsSubtasks(task);
+    setupSubtaskEventListeners(taskId);
     addTaskOverlayRef.classList.remove('d-none');
     setTimeout(() => {
         let overlayContainerRef = document.querySelector('.board-card-detail-container');
@@ -101,4 +102,24 @@ function generateSubtasksArray(task) {
 function transformTaskCategoryToClassName(taskCategory) {
     const categoryClassName = taskCategory.toLowerCase().replace(/\s+/g, '-');
     return categoryClassName;
+}
+
+function setupSubtaskEventListeners(taskId) {
+    const checkboxes = document.querySelectorAll('#cardDetailSubtasksContent input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+        checkbox.addEventListener('change', (e) => {
+            const subtaskId = e.target.id;
+            const isChecked = e.target.checked;
+            console.log(`Subtask ${subtaskId} is now ${isChecked ? 'completed' : 'not completed'}`);
+        });
+    });
+}
+
+function getSubtaskStates() {
+    const states = [];
+    const checkboxes = document.querySelectorAll('#cardDetailSubtasksContent input[type="checkbox"]');
+    checkboxes.forEach(cb => {
+        states.push({ id: cb.id, completed: cb.checked });
+    });
+    return states;
 }

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -106,9 +106,12 @@ function transformTaskCategoryToClassName(taskCategory) {
 }
 
 /**
- * Sets up event listeners for the subtask checkboxes.
+ * Attaches change event listeners to all subtask checkboxes in the task detail view.
+ * 
+ * When a checkbox is toggled, the corresponding subtask's completion state is updated
+ * using the `updateSubtaskState` function.
  *
- * @param {number|string} taskId - The unique identifier of the task.
+ * @param {string} taskId - The unique identifier of the task whose subtasks are being tracked.
  */
 function setupSubtaskEventListeners(taskId) {
     const checkboxes = document.querySelectorAll('#cardDetailSubtasksContent input[type="checkbox"]');
@@ -116,16 +119,21 @@ function setupSubtaskEventListeners(taskId) {
         checkbox.addEventListener('change', (e) => {
             const subtaskId = e.target.id;
             const isChecked = e.target.checked;
-            updateSubtaskState(subtaskId, isChecked);        });
+            updateSubtaskState(subtaskId, isChecked);
+            });
     });
 }
 
+
 /**
- * Updates the state of a subtask.
+ * Updates the completion state of a specific subtask for the currently open task.
+ * 
+ * Retrieves the current open task from the DOM, identifies the subtask by its ID,
+ * and sets its `completed` property to the provided checkbox state.
+ * The updated subtask state is stored back in the global `currentTasksData`.
  *
- * @param {number|string} taskId - The unique identifier of the task.
- * @param {number|string} subtaskId - The unique identifier of the subtask.
- * @param {boolean} isChecked - The new completed state of the subtask.
+ * @param {string} subtaskId - The unique identifier of the subtask to update.
+ * @param {boolean} isChecked - Indicates whether the subtask is completed (`true`) or not (`false`).
  */
 function updateSubtaskState(subtaskId, isChecked) {
     const currentOpenTask = document.getElementById("boardCardDetails");

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -115,9 +115,7 @@ function setupSubtaskEventListeners(taskId) {
         checkbox.addEventListener('change', (e) => {
             const subtaskId = e.target.id;
             const isChecked = e.target.checked;
-            updateSubtaskState(subtaskId, isChecked);
-            console.log(`Subtask ${subtaskId} is now ${isChecked ? 'completed' : 'not completed'}`);
-        });
+            updateSubtaskState(subtaskId, isChecked);        });
     });
 }
 
@@ -129,17 +127,9 @@ function setupSubtaskEventListeners(taskId) {
  * @param {boolean} isChecked - The new completed state of the subtask.
  */
 function updateSubtaskState(subtaskId, isChecked) {
-    // Implement the logic to update the subtask state in your data model
-    // For example, you might update the task object and save it to local storage or a server
-    // const task = getTaskById(taskId); // Implement this function to get the task by its ID
     const currentOpenTask = document.getElementById("boardCardDetails");
     const taskId = currentOpenTask.dataset.taskId;
-    console.log(taskId); 
-    const task = currentTasksData[taskId];   
-    console.log(task); 
-    console.log(subtaskId);
-    console.log("subtasks Inhalt:", task.subtasks);
-    console.log("Typ:", typeof task.subtasks);
+    const task = currentTasksData[taskId];
     const subtask = task.subtasks[subtaskId];
     if (subtask) {
         subtask.completed = isChecked;

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -133,7 +133,6 @@ function updateSubtaskState(subtaskId, isChecked) {
     const subtask = task.subtasks[subtaskId];
     if (subtask) {
         subtask.completed = isChecked;
-        // saveTask(task); // Implement this function to save the updated task
-        console.log(`Subtask ${subtaskId} updated to ${isChecked ? 'completed' : 'not completed'}`);      
+        currentTasksData[taskId].subtasks[subtaskId].completed = isChecked;  
     }
 }

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -12,7 +12,6 @@ function showBoardCardDetails(taskId) {
     addTaskOverlayRef.innerHTML += cardDetailsOverlayHTMLTemplate(task, categoryClassName);
     renderCardDetailsAssignedUsers(currentTasksData[taskId], taskId);
     renderCardDetailsSubtasks(task);
-    setupSubtaskEventListeners(taskId);
     addTaskOverlayRef.classList.remove('d-none');
     setTimeout(() => {
         let overlayContainerRef = document.querySelector('.board-card-detail-container');
@@ -75,6 +74,7 @@ function renderCardDetailsSubtasks(task) {
         const subtask = subtasksArray[subtaskIndex];
         subtasksContent.innerHTML += cardDetailSubtasksContentTemplate(subtask);
     }
+    setupSubtaskEventListeners(task.id);
 }
 
 /**
@@ -104,22 +104,46 @@ function transformTaskCategoryToClassName(taskCategory) {
     return categoryClassName;
 }
 
+/**
+ * Sets up event listeners for the subtask checkboxes.
+ *
+ * @param {number|string} taskId - The unique identifier of the task.
+ */
 function setupSubtaskEventListeners(taskId) {
     const checkboxes = document.querySelectorAll('#cardDetailSubtasksContent input[type="checkbox"]');
     checkboxes.forEach(checkbox => {
         checkbox.addEventListener('change', (e) => {
             const subtaskId = e.target.id;
             const isChecked = e.target.checked;
+            updateSubtaskState(subtaskId, isChecked);
             console.log(`Subtask ${subtaskId} is now ${isChecked ? 'completed' : 'not completed'}`);
         });
     });
 }
 
-function getSubtaskStates() {
-    const states = [];
-    const checkboxes = document.querySelectorAll('#cardDetailSubtasksContent input[type="checkbox"]');
-    checkboxes.forEach(cb => {
-        states.push({ id: cb.id, completed: cb.checked });
-    });
-    return states;
+/**
+ * Updates the state of a subtask.
+ *
+ * @param {number|string} taskId - The unique identifier of the task.
+ * @param {number|string} subtaskId - The unique identifier of the subtask.
+ * @param {boolean} isChecked - The new completed state of the subtask.
+ */
+function updateSubtaskState(subtaskId, isChecked) {
+    // Implement the logic to update the subtask state in your data model
+    // For example, you might update the task object and save it to local storage or a server
+    // const task = getTaskById(taskId); // Implement this function to get the task by its ID
+    const currentOpenTask = document.getElementById("boardCardDetails");
+    const taskId = currentOpenTask.dataset.taskId;
+    console.log(taskId); 
+    const task = currentTasksData[taskId];   
+    console.log(task); 
+    console.log(subtaskId);
+    console.log("subtasks Inhalt:", task.subtasks);
+    console.log("Typ:", typeof task.subtasks);
+    const subtask = task.subtasks[subtaskId];
+    if (subtask) {
+        subtask.completed = isChecked;
+        // saveTask(task); // Implement this function to save the updated task
+        console.log(`Subtask ${subtaskId} updated to ${isChecked ? 'completed' : 'not completed'}`);      
+    }
 }

--- a/scripts/templates/cardDetailsOverlayTemplate.js
+++ b/scripts/templates/cardDetailsOverlayTemplate.js
@@ -98,13 +98,13 @@ function cardDetailAssigneeContentTemplate(task, assigneeId, taskId) {
  * @returns {string} The HTML string representing the subtask element.
  */
 function cardDetailSubtasksContentTemplate(subtask) {
-       return `
-        <div class="card-detail-subtasks-tasks">
-            <label class="custom-checkbox">
-                <input type="checkbox" id="${subtask.id}" name="${subtask.id}" ${subtask.completed ? 'checked' : ''}>
-                <span class="checkmark"></span>
-                <span class="subtask-title">${subtask.title}</span>
-            </label>
-        </div>
-    `;
+    return `
+     <div class="card-detail-subtasks-tasks">
+         <label class="custom-checkbox">
+             <input type="checkbox" id="${subtask.id}" name="${subtask.id}" ${subtask.completed ? 'checked' : ''}>
+             <span class="checkmark"></span>
+             <span class="subtask-title">${subtask.title}</span>
+         </label>
+     </div>
+ `;
 }

--- a/styles/card-details.css
+++ b/styles/card-details.css
@@ -189,8 +189,8 @@
 
 .custom-checkbox input[type="checkbox"] {
   appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 24px;
+  height: 24px;
   border: 2px solid #2A3647 !important;
   border-radius: 3px;
   cursor: pointer !important;


### PR DESCRIPTION
Die Subtasks können nun im CardDetailOverlay angepasst werden. 

Wenn der Status eines Subtasks verändert wird, wird dieses zuerst im currentTaskData zwischengespeichert. 
Beim schließen des Overlays wird dann auch der Server mit der vorhanden Funktion geupdatet, um unnötig viele Schreibzugriffe auf den Server zu verhindern.


Nebenbei hab ich das Problem mit der Größe der Checkboxen im gecheckten Zustand gefixed. 
In Figma ist die checkbox selber 24px und der Inhalt nur 16px.

<img width="1640" alt="image" src="https://github.com/user-attachments/assets/7a1f969b-abb3-4cac-97e2-cb747e9608d6" />
