### PR TITLE
The placeholder flickering is eliminated

### DIFF
--- a/scripts/boardCardDragDrop.js
+++ b/scripts/boardCardDragDrop.js
@@ -6,18 +6,77 @@ let currentDraggedCardId = null;
 
 
 /**
- * Handles the dragover event by preventing the default behavior
- * and highlighting the target column if necessary.
+ * Tracks the current column we are hovering over
+ * @type {string|null}
+ */
+let currentHoveredColumn = null;
+
+
+/**
+ * Handles the dragover event by preventing the default behavior.
+ * Also maintains the currentHoveredColumn state for tracking.
  *
  * @param {DragEvent} ev - The dragover event object.
  */
 function dragoverHandler(ev) {
     ev.preventDefault();
+    
     const columnCategory = ev.currentTarget.id;
-    const existingPlaceholder = document.getElementById('placeholder');
-    if (!existingPlaceholder || existingPlaceholder.parentElement.id !== columnCategory) {
-        highlightCardContainer(columnCategory);
+
+    if (currentHoveredColumn !== columnCategory) {
+        currentHoveredColumn = columnCategory;
     }
+}
+
+
+/**
+ * Handles when a dragged element leaves a column.
+ * We need to make sure we're really leaving the column, not just moving between elements.
+ *
+ * @param {string} columnId - The ID of the column being left.
+ */
+function removeHighlightCardContainer(columnId) {
+    const relatedTarget = event.relatedTarget;
+    const currentTarget = document.getElementById(columnId);
+    
+    if (currentTarget && relatedTarget && 
+        (currentTarget.contains(relatedTarget) || currentTarget === relatedTarget)) {
+        return;
+    }
+    
+    const placeholder = document.getElementById('placeholder');
+    if (placeholder && placeholder.parentElement.id === columnId) {
+        placeholder.remove();
+    }
+    
+    if (currentHoveredColumn === columnId) {
+        currentHoveredColumn = null;
+    }
+}
+
+
+/**
+ * Highlights the target column by adding a placeholder element
+ * to indicate where the dragged card can be dropped.
+ *
+ * @param {string} columnCategory - The ID of the column to highlight.
+ */
+function highlightCardContainer(columnCategory) {
+    const column = document.getElementById(columnCategory);
+    const existingPlaceholder = document.getElementById('placeholder');
+    
+    if (existingPlaceholder && existingPlaceholder.parentElement === column) {
+        return;
+    }
+
+    if (existingPlaceholder) {
+        existingPlaceholder.remove();
+    }
+
+    const placeholder = document.createElement('div');
+    placeholder.classList.add('highlight-card-container');
+    placeholder.id = 'placeholder';
+    column.appendChild(placeholder);
 }
 
 
@@ -44,42 +103,13 @@ function moveCardTo(category, columnCategory) {
     const card = document.getElementById(currentDraggedCardId);
     card.classList.remove('tilt-animation');
     currentTasksData[currentDraggedCardId]['status'] = category;
-    removeHighlightCardContainer(columnCategory);
+    
+    const placeholder = document.getElementById('placeholder');
+    if (placeholder) {
+        placeholder.remove();
+    }
+    
+    currentHoveredColumn = null;
     updateTasksInDatabase(currentTasksData);
     renderTasks(currentTasksData);
-}
-
-
-/**
- * Highlights the target column by adding a placeholder element
- * to indicate where the dragged card can be dropped.
- *
- * @param {string} columnCategory - The ID of the column to highlight.
- */
-function highlightCardContainer(columnCategory) {
-    const column = document.getElementById(columnCategory);
-    const existingPlaceholder = document.getElementById('placeholder');
-    if (!existingPlaceholder || existingPlaceholder.parentElement !== column) {
-        if (existingPlaceholder) {
-            existingPlaceholder.remove();
-        }
-        const placeholder = document.createElement('div');
-        placeholder.classList.add('highlight-card-container');
-        placeholder.id = 'placeholder';
-        column.appendChild(placeholder);
-    }
-}
-
-
-/**
- * Removes the highlight placeholder from the specified column.
- *
- * @param {string} columnCategory - The ID of the column from which to remove the placeholder.
- */
-function removeHighlightCardContainer(columnCategory) {
-    const column = document.getElementById(columnCategory);
-    const placeholder = document.getElementById('placeholder');
-    if (placeholder && placeholder.parentElement === column) {
-        column.removeChild(placeholder);
-    }
 }


### PR DESCRIPTION
Beim Hovern des Platzhalters wurde ein dragLeave-Event ausgelöst - der Platzhalter wurde entfernt. Gleichzeitig wird aber auch ein dragEnter-Event ausgelöst (Bubbeling - weil wir sind eigentlich noch in der Spalte) - der Platzhalter wird neu erstellt.

Jetzt ist es so, wenn currentTarget.contains(relatedTarget) wahr ist, bedeutet das:
"Das Element, zu dem du gehst, ist immer noch innerhalb der Spalte, obwohl ein dragLeave-Event durch Bubbling ausgelöst wurde."
Dann wird das Event einfach ignoriert und der Platzhalter bleibt unverändert.