### PR TITLE
Bug fix card details(edit)overlay close overlay close dropdown

### DIFF
--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -40,7 +40,9 @@ function closeBoardCardDetails(event) {
     setTimeout(() => {
         overlay.classList.add('d-none');
     }, 300);
-
+    
+    renderTasks(currentTasksData);
+    updateTasksInDatabase(currentTasksData);
 }
 
 /**

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -31,7 +31,7 @@ function closeBoardCardDetails(event) {
     let overlay = document.getElementById('boardCardDetails');
     let overlayContainer = document.getElementById('boardCardDetailContainer');
 
-    if (event.target.closest('.board-card-detail-container') && !event.target.closest('.close-btn')) {
+    if (event.target.closest('.board-card-detail-container') && !event.target.closest('.close-btn') || event.target.closest('.board-card-edit-container') && !event.target.closest('.close-btn')) {
         event.stopPropagation();
         return;
     }

--- a/scripts/boardCardDetails.js
+++ b/scripts/boardCardDetails.js
@@ -31,19 +31,16 @@ function closeBoardCardDetails(event) {
     let overlay = document.getElementById('boardCardDetails');
     let overlayContainer = document.getElementById('boardCardDetailContainer');
 
-    updateTasksInDatabase(currentTasksData);
-    if (event.target.closest('.board-card-edit-container') || event.target.closest('.input-container')) {
+    if (event.target.closest('.board-card-detail-container') && !event.target.closest('.close-btn')) {
         event.stopPropagation();
         return;
     }
 
-    if (event.target.closest('.close-btn')) {
-        overlayContainer.classList.remove('show');
+    overlayContainer.classList.remove("show");
+    setTimeout(() => {
+        overlay.classList.add('d-none');
+    }, 300);
 
-        setTimeout(() => {
-            overlay.classList.add('d-none');
-        }, 300);
-    }
 }
 
 /**

--- a/scripts/boardCardDetailsEdit.js
+++ b/scripts/boardCardDetailsEdit.js
@@ -31,7 +31,7 @@ document.addEventListener('click', (event) => {
         event.stopPropagation();
         return;
     }
-    closeBoardCardDetails(event);
+    // closeBoardCardDetails(event);
 });
 
 
@@ -42,62 +42,12 @@ document.addEventListener('click', (event) => {
  * - If found, adds a click event listener to it.
  * - When clicked, the button triggers saving the edited task and closing the task details overlay.
  */
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', (event) => {
     const okButton = document.getElementById('ok-button');
     if (okButton) {
         okButton.addEventListener('click', () => {
             saveEditedTask();
-            closeBoardCardDetails(); 
-        });
-    }
-});
-
-
-/**
- * Handles global click events for managing overlay visibility and dropdown behavior.
- * This listener:
- * - Closes the assigned contacts dropdown if the user clicks outside of it.
- * - Closes the board card edit overlay when the close button is clicked or a click occurs outside the overlay.
- * - Prevents propagation when clicking inside the edit container to avoid unintended closures.
- * Note: Requires `isClickOutsideOverlay` and `closeBoardCardDetails()` to be defined elsewhere.
- * 
- * @param {MouseEvent} event - The click event triggered by the user.
- */
-document.addEventListener('click', (event) => {
-    const dropdown = document.getElementById('dropdownOptions');
-    const dropdownToggle = document.getElementById('assignedDropdown');
-    const editContainer = document.querySelector('.board-card-edit-container');
-
-    if (
-        dropdown && dropdownToggle &&
-        !dropdown.contains(event.target) &&
-        !dropdownToggle.contains(event.target)
-    ) {
-        dropdown.classList.add('d-none');
-    }
-
-    if (editContainer && editContainer.contains(event.target)) {
-        event.stopPropagation();
-        return;
-    }
-
-    closeBoardCardDetails(event);
-});
-
-
-/**
- * Waits for the DOM to be fully loaded before executing any code that interacts with the page elements.
- * 
- * - Looks for an element with the ID 'ok-button'.
- * - If found, adds a click event listener to it.
- * - When clicked, the button triggers saving the edited task and closing the task details overlay.
- */
-document.addEventListener('DOMContentLoaded', () => {
-    const okButton = document.getElementById('ok-button');
-    if (okButton) {
-        okButton.addEventListener('click', () => {
-            saveEditedTask();
-            closeBoardCardDetails();
+            closeBoardCardDetails(event); 
         });
     }
 });

--- a/scripts/boardCardDetailsEdit.js
+++ b/scripts/boardCardDetailsEdit.js
@@ -98,6 +98,7 @@ function setupDropdownToggle() {
 function toggleDropdown() {
     const dropdown = document.getElementById('dropdownOptions');
     if (dropdown) {
+        addCloseListener(getParentContainer())
         dropdown.classList.toggle('d-none');
     }
 }

--- a/scripts/templates/cardDetailsOverlayTemplate.js
+++ b/scripts/templates/cardDetailsOverlayTemplate.js
@@ -20,7 +20,7 @@ function cardDetailsOverlayHTMLTemplate(task, categoryClassName) {
         <div class="board-card-detail-container" id="boardCardDetailContainer">
             <div class="board-card-detail-header">
                 <span class="card-category card-category-detail ${categoryClassName}">${task.category}</span>
-                <button class="close-btn"><img src="../assets/icons/close_btn.svg" alt="close" /></button>
+                <button class="close-btn" onclick="closeBoardCardDetails(event)"><img src="../assets/icons/close_btn.svg" alt="close" /></button>
             </div>
             <h4 class="card-detail-title">${task.title}</h4>
             <p class="card-detail-description">${task.description}</p>


### PR DESCRIPTION
Sowohl das CardDetails Overlay, als auch das CardEdit Overlay können jetzt wieder geschlossen werden durch den Schließen Button oder wenn man außerhalb des Overlays klickt.

Außerdem wird das Dropdown für Assigned To geschlossen, wenn außerhalb des Dropdowns geklickt wird.

Weiterhin kann über den OK Button die Änderungen an der Task gespeichert werden.

Beim schließen des CardDetail Overlays werden die Tasks im Board und in der Datenbank aktualisiert, um die Änderungen der Subtasks darzustellen.