### PR TITLE
fixed padding problem on mobile view

### DIFF
--- a/styles/add-task-style.css
+++ b/styles/add-task-style.css
@@ -715,7 +715,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
 @media (max-width: 768px) {
     .container {
-        padding: 8px 16px 84px 16px;
+        padding: 8px 16px 84px 0;
     }
 
     .container h1 {


### PR DESCRIPTION
padding-left der Klasse container ab der mobilen Ansicht auf 0 gesetzt, sodass lediglich padding-left von main übrig bleibt. 

AddTaskResponsive centralized.