### PR TITLE
Bug - Wiggle navbar

### DIFF
--- a/styles/general-navbar-style.css
+++ b/styles/general-navbar-style.css
@@ -134,7 +134,6 @@ a.active .menu-summary-btn {
 .menu-summary-btn:hover {
 	background-color: #233b59;
 	height: 46px;
-	transform: translateY(-2px);
 }
 
 .summary-menu a {


### PR DESCRIPTION
![Screenshot 2025-05-07 171417](https://github.com/user-attachments/assets/d2e7f54d-88a1-4c48-97f9-8a390148e9ef)
Der Hover-Effekt translateY(-2px) wurde bei den Summary-Buttons entfernt, um unerwünschte Layout-Verschiebungen zu vermeiden.