### PR TITLE
Vertikaler scrollbalken-overflow-y: hidden

### DIFF
--- a/styles/card.css
+++ b/styles/card.css
@@ -49,7 +49,7 @@
   scrollbar-width: none; 
   scroll-behavior: smooth;
   overflow-x: auto !important;
-  overflow-y: auto !important;
+  overflow-y: hidden !important;
 
 }
 


### PR DESCRIPTION
Bitte überprüfen, ob der vertikale Scrollbalken im Card-Container des Boards noch angezeigt wird.