### PR TITLE
the action btn overlay for contacts mobile view is now hidden

### DIFF
--- a/html/contacts.html
+++ b/html/contacts.html
@@ -37,7 +37,7 @@
   <script src="../scripts/checkLandscape.js" defer></script>
 </head>
 
-<body onload="init()">
+<body onload="init()" class="body-contacts">
   <header>
     <div class="header">
       <img class="mobile-join-logo" src="../assets/img/join-logo-dark.svg" alt="join-logo">

--- a/scripts/mobileContacts.js
+++ b/scripts/mobileContacts.js
@@ -228,7 +228,7 @@ function closeOverlayOnClickOutside(event) {
  */
 function showMobileActionButtonsOverlay() {
     const overlay = document.getElementById('mobile-edit-contact-action-btn-overlay');
-
+    
     overlay.classList.add('show');
     document.removeEventListener("click", closeOverlayOnClickOutside);
 

--- a/styles/contacts.css
+++ b/styles/contacts.css
@@ -3,6 +3,10 @@ html {
   overflow: hidden;
 }
 
+.body-contacts {
+  position: relative;
+}
+
 .contact-view {
   display: flex;
   justify-content: flex-start;
@@ -256,7 +260,7 @@ html {
   }
 
   .contact-detail-header {
-    width: 480px;
+    width: 100%;
   }
 
   .contact-detail-header h2 {
@@ -332,6 +336,6 @@ html {
   }
 
   #header-container {
-    width: 62%;
+    width: 100%;
   }
 }

--- a/styles/render_contacts.css
+++ b/styles/render_contacts.css
@@ -407,6 +407,7 @@
         flex-direction: column;
         align-items: start;
         justify-content: end;
+        min-width: 300px;
         width: 480px;
         transform: none;
         transition: none
@@ -414,6 +415,7 @@
 
     .contact-detail.show {
         transform: none;
+        width: 300px;
     }
 
     .contact-list-wrapper {


### PR DESCRIPTION
Das Action-btn-Overlay für die mobile Ansicht ist nun nicht mehr sichtbar, damit kann auch nicht mehr gescrollt werden.