### PR TITLE
scroll bar removed

### DIFF
--- a/styles/summary.css
+++ b/styles/summary.css
@@ -252,6 +252,23 @@ img {
         padding-bottom: 80px;
     }
 
+    html,
+    body {
+        overscroll-behavior: none;
+        overflow: hidden !important;
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+    }
+
+    .card,
+    .large-card {
+        height: clamp(300px, 60vh, 700px);
+        max-height: 80vh;
+        padding: 1rem;
+    }
+
     .card {
         height: 160px;
         padding: 0 20px;
@@ -300,6 +317,16 @@ img {
     .dashboard {
         padding: 30px 30px 60px 30px;
         width: 435px;
+    }
+
+    html,
+    body {
+        overscroll-behavior: none;
+        overflow: hidden !important;
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
     }
 
     .layout img {
@@ -367,6 +394,16 @@ img {
     main {
         width: calc(100% - 20px) !important;
         margin-left: -10px;
+    }
+
+    html,
+    body {
+        overscroll-behavior: none;
+        overflow: hidden !important;
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
     }
 
     .card {


### PR DESCRIPTION
![Screenshot 2025-05-19 094012](https://github.com/user-attachments/assets/028b5dc9-a49e-47b9-a6a4-155ae8b86e2f)
Kein versehentliches „Zittern“ bei Touchgeräten.
Das horizontale und vertikale Scrollen wird in der mobilen Ansicht und unter 1380px deaktiviert.