### PR TITLE
editCard.css max-height responsive

### DIFF
--- a/styles/editCard.css
+++ b/styles/editCard.css
@@ -320,3 +320,24 @@
     padding: 4px 5px;
   }
 }
+
+@media screen and (max-height: 940px) {
+.board-card-edit-content-wrapper {
+    width: 100%;
+    overflow-y: scroll;
+    overflow-x: hidden;
+}
+
+  .board-card-edit-content-wrapper::-webkit-scrollbar {
+    width: 4px; 
+  }
+
+  .board-card-edit-content-wrapper::-webkit-scrollbar-track {
+    background: transparent; 
+  }
+
+  .board-card-edit-content-wrapper::-webkit-scrollbar-thumb {
+    background-color: rgba(0, 0, 0, 0.2); 
+    border-radius: 4px;
+  }
+}


### PR DESCRIPTION
![Screenshot 2025-05-19 103928](https://github.com/user-attachments/assets/4d275bc0-0748-4d39-9d44-12010b1ebad8)
![Screenshot 2025-05-19 100605](https://github.com/user-attachments/assets/1a8f23ad-48bd-4968-a54f-404ff3246d1d)
![Screenshot 2025-05-19 101941](https://github.com/user-attachments/assets/0be3c54f-e95b-486f-9d42-7f89346ec64b)
Bei niedriger Bildschirmhöhe (unter 940px) erscheint ein vertikaler Scrollbalken, sodass der Inhalt vollständig zugänglich bleibt – auch auf kleinen Geräten.