### PR TITLE
Board-Header-Bug

### DIFF
--- a/scripts/board.js
+++ b/scripts/board.js
@@ -367,3 +367,18 @@ function getBoardContainers() {
 window.addEventListener('DOMContentLoaded', () => {
     init();
 });
+
+/**
+ * Adds a listener to the window's resize event.
+ * 
+ * When the window is resized and its width becomes greater than 1124 pixels,
+ * the page will automatically scroll to the top with a smooth scrolling behavior.
+ *
+ * This is useful for resetting scroll position when switching from mobile/tablet
+ * view to desktop layout to avoid layout glitches such as elements appearing out of place.
+ */
+window.addEventListener('resize', () => {
+  if (window.innerWidth > 1124) {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+});


### PR DESCRIPTION
![Screenshot 2025-05-19 111659](https://github.com/user-attachments/assets/2d40097e-1a69-46d8-bb84-fd94fd62dd21)
![Screenshot 2025-05-19 111937](https://github.com/user-attachments/assets/0eb181f1-ce0d-4de0-88f3-b70b706b65af)

Beim Zurückwechseln auf eine größere Bildschirmbreite wurde der Header aufgrund der Scrollposition nicht mehr angezeigt.