### PR TITLE
add task responsiv

### DIFF
--- a/styles/addTask.css
+++ b/styles/addTask.css
@@ -683,9 +683,27 @@ input[type="date"]::-webkit-calendar-picker-indicator {
     margin-bottom: 10px;
 }
 
+@media (max-width: 1500px) {
+   .container {
+    padding: 10px 96px 0 96px;
+    max-height: 80vh;
+    overflow-y: auto;
+    }
+
+    html, body {
+    height: 100vh;
+    margin: 0;
+    overflow: hidden; 
+}
+}
+
 @media (max-width: 1200px) {
     .form-column-right {
         padding-top: 20px;
+    }
+
+    .container {
+    padding: 10px 96px 0 96px;
     }
 
     .prio-buttons {
@@ -729,6 +747,7 @@ input[type="date"]::-webkit-calendar-picker-indicator {
 
     .field-required {
         margin-top: 0;
+        margin-bottom: 85px;
     }
 
     .buttons {


### PR DESCRIPTION
![Screenshot 2025-05-21 140800](https://github.com/user-attachments/assets/ee8176bf-7791-47e9-83df-52fdad6b7a00)
![Screenshot 2025-05-21 140713](https://github.com/user-attachments/assets/cfb7cfba-f84f-4c8c-b097-7eb19dbc5932)
![Screenshot 2025-05-21 140521](https://github.com/user-attachments/assets/6d04cfe3-e611-48f7-9b15-702e7a00e24b)
![Screenshot 2025-05-21 140607](https://github.com/user-attachments/assets/eee26af6-21b8-4211-8235-fdbffdc137e5)
Der Add Task-Bereich ist über eine Scrollbar vollständig einsehbar. Der Header bleibt fixiert, während nur das Overlay scrollt. Bei kleineren Bildschirmgrößen und geringer Höhe lässt sich der gesamte Inhalt des Containers nach unten scrollen.